### PR TITLE
Reduce amount of space zoomed images fill

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,7 +42,8 @@ plugins:
       post_url_format: "{slug}"
       post_excerpt_separator: 
   - search
-  - glightbox # used for zoom functionality, see https://squidfunk.github.io/mkdocs-material/reference/images/#lightbox
+  - glightbox: # used for zoom functionality, see https://squidfunk.github.io/mkdocs-material/reference/images/#lightbox
+      width: 90%
 
 
 markdown_extensions:


### PR DESCRIPTION
No this isn't part of the ARG, but the question about glightbox yesterday in the #s4-puzzle channel reminded me to go and fix this.

Issue was most noticeable on the Transparency Reports, where it was hard to quickly click off the image without zooming in further or having to move your cursor all the way to the corner.