### PR TITLE
Update wrench.md

### DIFF
--- a/docs/documentation/minecraft/tweaks/wrench.md
+++ b/docs/documentation/minecraft/tweaks/wrench.md
@@ -4,6 +4,8 @@ The Wrench offers a convenient way to rotate blocks in Survival mode.
 
 ## Obtaining a Wrench
 
+Drop the items on Soul Sand/Soil and then light the block to create Soul Fire.
+
 - To obtain a basic "Rotate" wrench, drop a Carrot on a Stick into Soul Fire.
     - For the advanced wrenches:
         - Flip Wrench: Drop a Carrot on a Stick + Copper Ingot into Soul Fire.


### PR DESCRIPTION
The advanced wrenches can't be created by dropping the items. You have to light the block after dropping the items.